### PR TITLE
Potential fix for code scanning alert no. 4: Missing CSRF middleware

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -3,6 +3,7 @@ const cors = require('cors');
 const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
 const cookieParser = require('cookie-parser');
+const csrf = require('csurf');
 require('dotenv').config();
 
 const app = express();
@@ -20,6 +21,9 @@ app.use(helmet({
 
 // CRITICAL: Cookie parser must come before routes that use cookies
 app.use(cookieParser());
+
+// CSRF protection - must come after cookie parser (and session, if used)
+app.use(csrf());
 
 // CORS configuration - Enhanced for image requests and multiple origins
 const allowedOrigins = [
@@ -42,7 +46,7 @@ app.use(cors({
     },
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'Cookie'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'Cookie', 'X-CSRF-Token'],
     exposedHeaders: ['Set-Cookie']
 }));
 

--- a/server/package.json
+++ b/server/package.json
@@ -29,7 +29,8 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.2",
     "nodemailer": "^7.0.6",
-    "pg": "^8.11.3"
+    "pg": "^8.11.3",
+    "csurf": "^1.11.0"
   },
   "devDependencies": {
     "concurrently": "^9.2.1",


### PR DESCRIPTION
Potential fix for [https://github.com/Ragib100/LocalFix/security/code-scanning/4](https://github.com/Ragib100/LocalFix/security/code-scanning/4)

In general, you fix this by adding standard CSRF protection middleware after cookie/session parsing but before your state‑changing routes. The middleware issues a per-session/per-request token that must be included in modifying requests (usually via a header or body field). Requests without a valid token are rejected, preventing cross-site request forgery.

For this codebase, the least disruptive fix that preserves existing functionality is:

1. Import a CSRF middleware (e.g., `csurf` from npm).
2. Initialize it right after `cookieParser()` (and, if you have `express-session` elsewhere, after that as well), so that all subsequent routes benefit from CSRF checks.
3. Configure it to use a header token, which works well with SPA frontends and CORS (for example, the frontend can send the token via `X-CSRF-Token`).
4. Ensure CORS allows that header so that browser requests with the CSRF token header are not blocked.

Since we can only touch `server/app.js` and only the shown snippet, the concrete steps are:

- Add `const csrf = require('csurf');` to the imports at the top of `server/app.js`.
- After `app.use(cookieParser());` add a new `app.use` that applies `csurf` and enables sending/reading the token via a header (we’ll use the default cookie/session backing; `csurf` will attach `req.csrfToken()`).
- Update the CORS configuration’s `allowedHeaders` to include the CSRF header name we choose (e.g., `X-CSRF-Token`), so the frontend can send it without CORS issues.

These changes introduce CSRF protection for all subsequent request handlers without altering their existing logic; they will still see the same `req.body`, `req.cookies`, etc., but unsafe cross-site requests lacking a valid token will now be rejected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
